### PR TITLE
Clean up dependency definitions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,14 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.6.2"
+Django = "^3.1.0"
+
+djangorestframework = { version = "^3.11.0", optional = true }
+
+[tool.poetry.extras]
+djangorestframework = ["djangorestframework"]
 
 [tool.poetry.dev-dependencies]
-Django = "^3.1.0"
 djangorestframework = "^3.11.0"
 pytest = "^6"
 pytest-django = "^4.5.2"


### PR DESCRIPTION
* Django is moved to a runtime dependency, rather than dev
* DRF is moved to an extra dependency